### PR TITLE
Fixed typo in Notebooks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ This will launch your web browser with the list of challenge categories:
 * Run the cells within the challenge notebook (Cell->Run All)
     * This will result in an expected unit test error
 * Solve the challenge and verify it passes the unit test
-* Check out the accompanying **Solution Notebook** for futher discussion
+* Check out the accompanying **Solution Notebook** for further discussion
 
 ### Nose Unit Tests
 


### PR DESCRIPTION
Fixed a typo in the Notebooks section. 'further' was spelled 'futher'.

Changing this single line is registering as 2 line changes, but only the content of line 333 is actually changing.

![screen shot 2015-07-07 at 5 14 38 pm](https://cloud.githubusercontent.com/assets/3507287/8560385/dc1a1c84-24cb-11e5-982d-5879f2c3fa77.png)
