### PR TITLE
Fixed typo for func() calls

### DIFF
--- a/staging/arrays_strings/reverse_words/reverse_words_challenge.ipynb
+++ b/staging/arrays_strings/reverse_words/reverse_words_challenge.ipynb
@@ -108,10 +108,10 @@
     "\n",
     "class UnitTest (object):\n",
     "    def testReverseWords(self):\n",
-    "            assert_equal(func('the sun is hot'), 'eht nus si toh')\n",
-    "            assert_equal(func(''), None)\n",
-    "            assert_equal(func('123 456 789'), '321 654 987')\n",
-    "            assert_equal(func('magic'), 'cigam')\n",
+    "            assert_equal(reverse_words('the sun is hot'), 'eht nus si toh')\n",
+    "            assert_equal(reverse_words(''), None)\n",
+    "            assert_equal(reverse_words('123 456 789'), '321 654 987')\n",
+    "            assert_equal(reverse_words('magic'), 'cigam')\n",
     "            print('Success: reverse_words')\n",
     "            \n",
     "def main():\n",
@@ -147,7 +147,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "version": "2.7.10"
   }
  },
  "nbformat": 4,

--- a/staging/arrays_strings/reverse_words/reverse_words_challenge.ipynb
+++ b/staging/arrays_strings/reverse_words/reverse_words_challenge.ipynb
@@ -78,14 +78,12 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def reverse_words (S):\n",
     "    #TODO: implement me\n",
-    "    pass "
+    "    pass"
    ]
   },
   {
@@ -99,24 +97,22 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from nose.tools import assert_equal\n",
     "\n",
     "class UnitTest (object):\n",
     "    def testReverseWords(self):\n",
-    "            assert_equal(reverse_words('the sun is hot'), 'eht nus si toh')\n",
-    "            assert_equal(reverse_words(''), None)\n",
-    "            assert_equal(reverse_words('123 456 789'), '321 654 987')\n",
-    "            assert_equal(reverse_words('magic'), 'cigam')\n",
+    "            assert_equal(func('the sun is hot'), 'eht nus si toh')\n",
+    "            assert_equal(func(''), None)\n",
+    "            assert_equal(func('123 456 789'), '321 654 987')\n",
+    "            assert_equal(func('magic'), 'cigam')\n",
     "            print('Success: reverse_words')\n",
     "            \n",
     "def main():\n",
     "    test = UnitTest()\n",
-    "    test.testReverseWords()\n",
+    "    test.testReverseWords(reverse_words)\n",
     "\n",
     "if __name__==\"__main__\":\n",
     "  main()"
@@ -140,7 +136,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 2.0
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",


### PR DESCRIPTION
Sorry, should have submitted an enhancement instead.