### PR TITLE
Change `ipython notebook` to `jupyter notebook`

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Run the notebook of challenges:
 ```
 $ git clone https://github.com/donnemartin/interactive-coding-challenges.git
 $ cd interactive-coding-challenges
-$ ipython notebook
+$ jupyter notebook
 ```
 
 This will launch your web browser with the list of challenge categories:


### PR DESCRIPTION
Subcommand `ipython notebook` is deprecated and will be removed in future versions.