### PR TITLE
Add duplicate-characters test for permutations

### DIFF
--- a/arrays_strings/permutation/permutation_solution.ipynb
+++ b/arrays_strings/permutation/permutation_solution.ipynb
@@ -58,7 +58,8 @@
     "* One or more empty strings -> False\n",
     "* 'Nib', 'bin' -> False\n",
     "* 'act', 'cat' -> True\n",
-    "* 'a ct', 'ca t' -> True"
+    "* 'a ct', 'ca t' -> True\n",
+    "* 'dog', 'doggo' -> False"
    ]
   },
   {
@@ -200,6 +201,7 @@
     "        assert_equal(func('Nib', 'bin'), False)\n",
     "        assert_equal(func('act', 'cat'), True)\n",
     "        assert_equal(func('a ct', 'ca t'), True)\n",
+    "        assert_equal(func('dog', 'doggo'), False)\n",
     "        print('Success: test_permutation')\n",
     "\n",
     "\n",

--- a/arrays_strings/permutation/test_permutation_solution.py
+++ b/arrays_strings/permutation/test_permutation_solution.py
@@ -9,6 +9,7 @@ class TestPermutation(object):
         assert_equal(func('Nib', 'bin'), False)
         assert_equal(func('act', 'cat'), True)
         assert_equal(func('a ct', 'ca t'), True)
+        assert_equal(func('dog', 'doggo'), False)
         print('Success: test_permutation')
 
 


### PR DESCRIPTION
Summary:
The current test cases for the "string permutation checker" problem do
not include a test case where the inputs have the same elements at
different multiplicities. Without this test case, the implementation

    return s1 is not None and s2 is not None and set(s1) == set(s2)

would pass all tests.

Test Plan:
First, change one of the implementations to the above implementation,
and see that the original tests still pass. Then, apply this patch to
add the new test case. Then, revert the implementation change to see all
tests pass again.