### PR TITLE
Include `Counter`-based permutation solution

### DIFF
--- a/arrays_strings/permutation/permutation_solution.ipynb
+++ b/arrays_strings/permutation/permutation_solution.ipynb
@@ -58,7 +58,8 @@
     "* One or more empty strings -> False\n",
     "* 'Nib', 'bin' -> False\n",
     "* 'act', 'cat' -> True\n",
-    "* 'a ct', 'ca t' -> True"
+    "* 'a ct', 'ca t' -> True\n",
+    "* 'dog', 'doggo' -> False"
    ]
   },
   {
@@ -200,6 +201,7 @@
     "        assert_equal(func('Nib', 'bin'), False)\n",
     "        assert_equal(func('act', 'cat'), True)\n",
     "        assert_equal(func('a ct', 'ca t'), True)\n",
+    "        assert_equal(func('dog', 'doggo'), False)\n",
     "        print('Success: test_permutation')\n",
     "\n",
     "\n",

--- a/arrays_strings/permutation/permutation_solution.ipynb
+++ b/arrays_strings/permutation/permutation_solution.ipynb
@@ -136,7 +136,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Code: Hash Map Lookup"
+    "## Code: Hash Map Lookup, using `collections.defaultdict`"
    ]
   },
   {
@@ -150,7 +150,7 @@
     "from collections import defaultdict\n",
     "\n",
     "\n",
-    "class PermutationsAlt(object):\n",
+    "class PermutationsDefaultdict(object):\n",
     "\n",
     "    def is_permutation(self, str1, str2):\n",
     "        if str1 is None or str2 is None:\n",
@@ -170,12 +170,38 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Unit Test"
+    "## Code: Hash Map Lookup, using `collections.Counter`"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from collections import Counter\n",
+    "\n",
+    "\n",
+    "class PermutationsCounter(object):\n",
+    "    \n",
+    "    def is_permutation(self, str1, str2):\n",
+    "        if str1 is None or str2 is None:\n",
+    "            return False\n",
+    "        return Counter(str1) == Counter(str2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Unit Test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
    "metadata": {
     "collapsed": false
    },
@@ -209,13 +235,17 @@
     "    test = TestPermutation()\n",
     "    permutations = Permutations()\n",
     "    test.test_permutation(permutations.is_permutation)\n",
+    "\n",
+    "    alternate_solutions = []\n",
     "    try:\n",
-    "        permutations_alt = PermutationsAlt()\n",
-    "        test.test_permutation(permutations_alt.is_permutation)\n",
+    "        alternate_solutions.append(PermutationsDefaultdict())\n",
+    "        alternate_solutions.append(PermutationsCounter())\n",
     "    except NameError:\n",
     "        # Alternate solutions are only defined\n",
     "        # in the solutions file\n",
     "        pass\n",
+    "    for permutations_alt in alternate_solutions:\n",
+    "        test.test_permutation(permutations_alt.is_permutation)\n",
     "\n",
     "\n",
     "if __name__ == '__main__':\n",
@@ -224,7 +254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {
     "collapsed": false
    },
@@ -233,6 +263,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Success: test_permutation\n",
       "Success: test_permutation\n",
       "Success: test_permutation\n"
      ]

--- a/arrays_strings/permutation/test_permutation_solution.py
+++ b/arrays_strings/permutation/test_permutation_solution.py
@@ -9,6 +9,7 @@ class TestPermutation(object):
         assert_equal(func('Nib', 'bin'), False)
         assert_equal(func('act', 'cat'), True)
         assert_equal(func('a ct', 'ca t'), True)
+        assert_equal(func('dog', 'doggo'), False)
         print('Success: test_permutation')
 
 

--- a/arrays_strings/permutation/test_permutation_solution.py
+++ b/arrays_strings/permutation/test_permutation_solution.py
@@ -17,13 +17,17 @@ def main():
     test = TestPermutation()
     permutations = Permutations()
     test.test_permutation(permutations.is_permutation)
+
+    alternate_solutions = []
     try:
-        permutations_alt = PermutationsAlt()
-        test.test_permutation(permutations_alt.is_permutation)
+        alternate_solutions.append(PermutationsDefaultdict())
+        alternate_solutions.append(PermutationsCounter())
     except NameError:
         # Alternate solutions are only defined
         # in the solutions file
         pass
+    for permutations_alt in alternate_solutions:
+        test.test_permutation(permutations_alt.is_permutation)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**NOTE:** This PR is based off of #158; GitHub doesn't allow me to specify that and narrow the commit range. Once #158 is merged, only the last commit in this PR will have any effect. If you know of a way to indicate this to GitHub, please feel free to change it or let me know.

---

Summary:
The `collections` module exposes a type `Counter`, which makes the code
much more readable for this solution. It would be a one-liner if not for
the `None`-checking.

Test Plan:
Existing unit tests suffice for the new implementation.

The `test_permutation_solution.py` file still fails when run by itself,
for the same reason as before: not only are alternate solutions only in
the notebook, but the `Permutations` solution is as well. Thus, there is
a `NameError` on line 18. If you comment this line out, it still "works"
(meaning, it still silently absorbs the subsequent `NameError`s).

Please note that I tested this under Python 2 within Jupyter.
I also pasted the function into a Python 3 REPL and unit-tested it
manually, but I don't have Jupyter for Python 3.