### PR TITLE
Update solution link for `better_compress_challenge`

### DIFF
--- a/arrays_strings/compress_alt/better_compress_challenge.ipynb
+++ b/arrays_strings/compress_alt/better_compress_challenge.ipynb
@@ -63,7 +63,7 @@
    "source": [
     "## Algorithm\n",
     "\n",
-    "Refer to the [Solution Notebook](http://nbviewer.ipython.org/github/donnemartin/interactive-coding-challenges/blob/master/arrays_strings/compress/compress_solution.ipynb).  If you are stuck and need a hint, the solution notebook's algorithm discussion might be a good place to start."
+    "Refer to the [Solution Notebook](http://nbviewer.ipython.org/github/donnemartin/interactive-coding-challenges/blob/master/arrays_strings/compress_alt/better_compress_solution.ipynb).  If you are stuck and need a hint, the solution notebook's algorithm discussion might be a good place to start."
    ]
   },
   {
@@ -139,7 +139,7 @@
    "source": [
     "## Solution Notebook\n",
     "\n",
-    "Review the [Solution Notebook](http://nbviewer.ipython.org/github/donnemartin/interactive-coding-challenges/blob/master/arrays_strings/compress/compress_solution.ipynb) for a discussion on algorithms and code solutions."
+    "Review the [Solution Notebook](http://nbviewer.ipython.org/github/donnemartin/interactive-coding-challenges/blob/master/arrays_strings/compress_alt/better_compress_solution.ipynb) for a discussion on algorithms and code solutions."
    ]
   }
  ],


### PR DESCRIPTION
The link to the solution on the `better_compress_challenge` notebook was linking to the solution for the standard `compress_challenge`.