### PR TITLE
Add assumption to str diff challenge to match the suggested solution

### DIFF
--- a/arrays_strings/str_diff/str_diff_challenge.ipynb
+++ b/arrays_strings/str_diff/str_diff_challenge.ipynb
@@ -34,6 +34,7 @@
    "source": [
     "## Constraints\n",
     "\n",
+    "* Assume two strings str1, str2, where str2 contains the same set of characters in str1 with one additional character.\n",
     "* Can we assume the strings are ASCII?\n",
     "    * Yes\n",
     "* Is case important?\n",

--- a/arrays_strings/str_diff/str_diff_solution.ipynb
+++ b/arrays_strings/str_diff/str_diff_solution.ipynb
@@ -76,7 +76,7 @@
     "\n",
     "Complexity:\n",
     "* Time: O(m+n), where m and n are the lengths of s, t\n",
-    "* Space: O(1), for the dict, where h is the unique chars in s"
+    "* Space: O(1), for the result, where the result takes always 1 space"
    ]
   },
   {

--- a/arrays_strings/str_diff/str_diff_solution.ipynb
+++ b/arrays_strings/str_diff/str_diff_solution.ipynb
@@ -76,7 +76,7 @@
     "\n",
     "Complexity:\n",
     "* Time: O(m+n), where m and n are the lengths of s, t\n",
-    "* Space: O(1), for the result, where the result takes always 1 space"
+    "* Space: O(1)"
    ]
   },
   {


### PR DESCRIPTION
- Add additional assumption in challenge 

The challenge is nice, but the assumptions in the challenge notebook do not accurately express what is assumed in the solution notebook, for it is assumed that the second string is the one with the additional character, e.g:

`assert_equal(solution.find_diff('abcde',` 'abcd'), 'e') -> AssertionError: None != 'e'`

so the solution does not work both ways.
In order for the solution to work both ways, the complexity would increase to O(m * n), and the code would have to change.

- Correct xor space complexity comment in solution. I think it is a copy-paste mistake.