### PR TITLE
Added __eq__ method to ensure invert_tree_challenge tests pass.

### DIFF
--- a/graphs_trees/bst/bst.py
+++ b/graphs_trees/bst/bst.py
@@ -7,7 +7,10 @@ class Node(object):
         self.parent = None
 
     def __repr__(self):
-        return str(self.data)
+        return 'Node<data=%s>' % (self.data,)
+
+    def __eq__(self, other):
+        return isinstance(other, Node) and self.data == other.data
 
 
 class Bst(object):


### PR DESCRIPTION
The `invert_tree_challenge` Jupyter notebook has a nose unit-test that looks like this:

    assert_equal(result, root)

Where `result` and `root` are `Node` objects. I wrote a solution to this challenge that involved creating a new `Node` object versus re-using the existing one, but this failed because there was no `__eq__` method defined in the `Node` class to enable comparison with other Nodes.

This minor pull request addresses three things:

1. Changes the `__repr__` method to aid debugging.
2. Adds an `__eq__` method to compare nodes in a tree.
3. Adds a newline at the end of the file.

Thanks!