### PR TITLE
Fix challenge notebook exception handling

### DIFF
--- a/math_probability/add_digits/add_digits_challenge.ipynb
+++ b/math_probability/add_digits/add_digits_challenge.ipynb
@@ -132,7 +132,7 @@
     "    test.test_add_digits(solution.add_digits)\n",
     "    try:\n",
     "        test.test_add_digits(solution.add_digits_optimized)\n",
-    "    except NameError:\n",
+    "    except AttributeError:\n",
     "        # Alternate solutions are only defined\n",
     "        # in the solutions file\n",
     "        pass\n",


### PR DESCRIPTION
if there is no `add_digits_optimized()` method, interpreter will raise `AttributeError` on line 134 (instead of `NameError`), which won't be caught by the `except` statement.