### PR TITLE
Update solution notebook link for str diff challenge

### DIFF
--- a/arrays_strings/str_diff/str_diff_challenge.ipynb
+++ b/arrays_strings/str_diff/str_diff_challenge.ipynb
@@ -62,7 +62,7 @@
    "source": [
     "## Algorithm\n",
     "\n",
-    "Refer to the [Solution Notebook]().  If you are stuck and need a hint, the solution notebook's algorithm discussion might be a good place to start."
+    "Refer to the [Solution Notebook](str_diff_solution.ipynb).  If you are stuck and need a hint, the solution notebook's algorithm discussion might be a good place to start."
    ]
   },
   {


### PR DESCRIPTION
I found a bug with the link to the solution notebook for the str_diff_challenge.

I'm super excited for my first ever albeit basic pull request. Please let me know if I am doing this incorrectly and I'll fix it.