### PR TITLE
Fix priority queue solution notebook link

### DIFF
--- a/arrays_strings/priority_queue/priority_queue_challenge.ipynb
+++ b/arrays_strings/priority_queue/priority_queue_challenge.ipynb
@@ -71,7 +71,7 @@
    "source": [
     "## Algorithm\n",
     "\n",
-    "Refer to the [Solution Notebook](https://github.com/donnemartin/interactive-coding-challenges/arrays_strings/priority_queue/priority_queue_solution.ipynb).  If you are stuck and need a hint, the solution notebook's algorithm discussion might be a good place to start."
+    "Refer to the [Solution Notebook](priority_queue_solution.ipynb).  If you are stuck and need a hint, the solution notebook's algorithm discussion might be a good place to start."
    ]
   },
   {

--- a/arrays_strings/priority_queue/priority_queue_challenge.ipynb
+++ b/arrays_strings/priority_queue/priority_queue_challenge.ipynb
@@ -181,7 +181,7 @@
    "source": [
     "## Solution Notebook\n",
     "\n",
-    "Review the [Solution Notebook](https://github.com/donnemartin/interactive-coding-challenges/arrays_strings/priority_queue/priority_queue_solution.ipynb) for a discussion on algorithms and code solutions."
+    "Review the [Solution Notebook](priority_queue_solution.ipynb) for a discussion on algorithms and code solutions."
    ]
   }
  ],

--- a/arrays_strings/str_diff/str_diff_challenge.ipynb
+++ b/arrays_strings/str_diff/str_diff_challenge.ipynb
@@ -62,7 +62,7 @@
    "source": [
     "## Algorithm\n",
     "\n",
-    "Refer to the [Solution Notebook]().  If you are stuck and need a hint, the solution notebook's algorithm discussion might be a good place to start."
+    "Refer to the [Solution Notebook](str_diff_solution.ipynb).  If you are stuck and need a hint, the solution notebook's algorithm discussion might be a good place to start."
    ]
   },
   {


### PR DESCRIPTION
I found a bug with two links to the solution notebook from priority_queue_challenge and fixed them to be accessed locally. 

Before it was pointing to the git repo which wouldn't work offline or for locally modified solution notebooks.