### PR TITLE
Update string diff test for None argument

### DIFF
--- a/arrays_strings/str_diff/str_diff_challenge.ipynb
+++ b/arrays_strings/str_diff/str_diff_challenge.ipynb
@@ -117,7 +117,7 @@
     "\n",
     "    def test_find_diff(self):\n",
     "        solution = Solution()\n",
-    "        assert_raises(TypeError, solution.find_diff, None)\n",
+    "        assert_raises(TypeError, solution.find_diff, None, None)\n",
     "        assert_equal(solution.find_diff('abcd', 'abcde'), 'e')\n",
     "        assert_equal(solution.find_diff('aaabbcdd', 'abdbacade'), 'e')\n",
     "        print('Success: test_find_diff')\n",


### PR DESCRIPTION
This test case was passing because too few positional arguments were being passed rather than None being passed as argument. I believe checking for None as arguments is the intent of the test.