### PR TITLE
Fix check prime test case discussions to match code

### DIFF
--- a/math_probability/generate_primes/check_prime_challenge.ipynb
+++ b/math_probability/generate_primes/check_prime_challenge.ipynb
@@ -50,7 +50,7 @@
     "\n",
     "* None -> Exception\n",
     "* Not an int -> Exception\n",
-    "* 20 -> 2, 3, 5, 7, 11, 13, 17, 19"
+    "* 20 -> [False, False, True, True, False, True, False, True, False, False, False, True, False, True, False, False, False, True, False, True]"
    ]
   },
   {

--- a/math_probability/generate_primes/check_prime_solution.ipynb
+++ b/math_probability/generate_primes/check_prime_solution.ipynb
@@ -49,7 +49,7 @@
     "\n",
     "* None -> Exception\n",
     "* Not an int -> Exception\n",
-    "* 20 -> 2, 3, 5, 7, 11, 13, 17, 19"
+    "* 20 -> [False, False, True, True, False, True, False, True, False, False, False, True, False, True, False, False, False, True, False, True]"
    ]
   },
   {


### PR DESCRIPTION
Adjusting documentation for expected output, since the solution returns the full result array, rather than the just the prime indices.

I think this documentation change will also hint at the use of Sieve of Eratosthenes.