### PR TITLE
add test case for properly deleting the head node of a linked list

### DIFF
--- a/linked_lists/linked_list/linked_list_challenge.ipynb
+++ b/linked_lists/linked_list/linked_list_challenge.ipynb
@@ -103,9 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class Node(object):\n",
@@ -173,9 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# %load test_linked_list.py\n",
@@ -255,7 +251,15 @@
     "        linked_list = LinkedList(head)\n",
     "        linked_list.delete(None)\n",
     "        assert_equal(linked_list.get_all_data(), [10])\n",
-    "\n",
+    "        \n",
+    "        print('Test: delete general case with match at the head')\n",
+    "        head = Node(10)\n",
+    "        linked_list = LinkedList(head)\n",
+    "        linked_list.insert_to_front('a')\n",
+    "        linked_list.insert_to_front('bc')\n",
+    "        linked_list.delete('bc')\n",
+    "        assert_equal(linked_list.get_all_data(), ['a', 10])\n",
+    "        \n",
     "        print('Test: delete general case with matches')\n",
     "        head = Node(10)\n",
     "        linked_list = LinkedList(head)\n",
@@ -310,23 +314,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.5.0"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.13"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/linked_lists/linked_list/linked_list_solution.ipynb
+++ b/linked_lists/linked_list/linked_list_solution.ipynb
@@ -171,9 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -288,9 +286,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%run linked_list.py"
@@ -306,9 +302,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -396,6 +390,14 @@
     "        linked_list = LinkedList(head)\n",
     "        linked_list.delete(None)\n",
     "        assert_equal(linked_list.get_all_data(), [10])\n",
+    "        \n",
+    "        print('Test: delete general case with match at the head')\n",
+    "        head = Node(10)\n",
+    "        linked_list = LinkedList(head)\n",
+    "        linked_list.insert_to_front('a')\n",
+    "        linked_list.insert_to_front('bc')\n",
+    "        linked_list.delete('bc')\n",
+    "        assert_equal(linked_list.get_all_data(), ['a', 10])\n",
     "\n",
     "        print('Test: delete general case with matches')\n",
     "        head = Node(10)\n",
@@ -442,9 +444,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -501,9 +501,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "version": "2.7.13"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
prior version didn't have test case specific to deleting the head node. Note that this breaks the alt_delete method because alt_delete doesn't properly handle the deletion of of the head node. I'm creating a separate pull request for that fix.