### PR TITLE
Fix graph adj_weights comment

### DIFF
--- a/graphs_trees/graph/graph_challenge.ipynb
+++ b/graphs_trees/graph/graph_challenge.ipynb
@@ -99,9 +99,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from enum import Enum  # Python 2 users: Run pip install enum34\n",
@@ -121,7 +119,7 @@
     "        self.visit_state = State.unvisited\n",
     "        self.incoming_edges = 0\n",
     "        self.adj_nodes = {}  # Key = key, val = Node\n",
-    "        self.adj_weights = {}  # Key = Node, val = weight\n",
+    "        self.adj_weights = {}  # Key = key, val = weight\n",
     "\n",
     "    def __repr__(self):\n",
     "        return str(self.key)\n",
@@ -173,9 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# %load test_graph.py\n",
@@ -280,9 +276,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
In the graph implementation challenge, there is a comment that incorrectly states the key for the weight dictionary should be a node instead of a key. It's correct however in the solution notebook. This PR just corrects the comment so users don't get confused and implement the wrong thing (as I did).