### PR TITLE
Refactor code

### DIFF
--- a/recursion_dynamic/knapsack_01/knapsack_solution.ipynb
+++ b/recursion_dynamic/knapsack_01/knapsack_solution.ipynb
@@ -42,7 +42,7 @@
     "* Can we assume the inputs are valid?\n",
     "    * No\n",
     "* Are the inputs in sorted order by val/weight?\n",
-    "    * Yes, if not we'd need to sort them first\n",
+    "    * Yes\n",
     "* Can we assume this fits memory?\n",
     "    * Yes"
    ]
@@ -132,9 +132,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class Item(object):\n",
@@ -158,9 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class Knapsack(object):\n",
@@ -170,15 +166,13 @@
     "            raise TypeError('input_items or total_weight cannot be None')\n",
     "        if not input_items or total_weight == 0:\n",
     "            return 0\n",
-    "        items = list([Item(label='', value=0, weight=0)] + input_items)\n",
+    "        items = [Item(label='', value=0, weight=0)] + input_items\n",
     "        num_rows = len(items)\n",
     "        num_cols = total_weight + 1\n",
-    "        T = [[None] * num_cols for _ in range(num_rows)]\n",
+    "        T = [[0] * num_cols for _ in range(num_rows)]\n",
     "        for i in range(num_rows):\n",
     "            for j in range(num_cols):\n",
-    "                if i == 0 or j == 0:\n",
-    "                    T[i][j] = 0\n",
-    "                elif j >= items[i].weight:\n",
+    "                if j >= items[i].weight:\n",
     "                    T[i][j] = max(items[i].value + T[i - 1][j - items[i].weight],\n",
     "                                  T[i - 1][j])\n",
     "                else:\n",
@@ -187,14 +181,10 @@
     "        i = num_rows - 1\n",
     "        j = num_cols - 1\n",
     "        while T[i][j] != 0:\n",
-    "            if T[i - 1][j] ==  T[i][j]:\n",
-    "                i -= 1\n",
-    "            elif T[i][j - 1] ==  T[i][j]:\n",
-    "                j -= 1\n",
-    "            else:\n",
+    "            if T[i][j] != T[i - 1][j]:\n",
     "                results.append(items[i])\n",
-    "                i -= 1\n",
     "                j -= items[i].weight\n",
+    "            i -= 1\n",
     "        return results"
    ]
   },
@@ -208,9 +198,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class KnapsackTopDown(object):\n",
@@ -255,9 +243,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class Result(object):\n",
@@ -328,9 +314,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -342,8 +326,7 @@
    ],
    "source": [
     "%%writefile test_knapsack.py\n",
-    "from nose.tools import assert_equal, assert_raises\n",
-    "\n",
+    "from nose.tools import assert_equal, assert_raises, assert_true\n",
     "\n",
     "class TestKnapsack(object):\n",
     "\n",
@@ -359,8 +342,9 @@
     "        total_weight = 8\n",
     "        expected_value = 13\n",
     "        results = knapsack.fill_knapsack(items, total_weight)\n",
-    "        assert_equal(results[0].label, 'd')\n",
-    "        assert_equal(results[1].label, 'b')\n",
+    "        labels = [x.label for x in results]\n",
+    "        assert_true('b' in labels)\n",
+    "        assert_true('d' in labels)\n",
     "        total_value = 0\n",
     "        for item in results:\n",
     "            total_value += item.value\n",
@@ -394,9 +378,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -410,6 +392,13 @@
    "source": [
     "%run -i test_knapsack.py"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -428,9 +417,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/recursion_dynamic/knapsack_01/test_knapsack.py
+++ b/recursion_dynamic/knapsack_01/test_knapsack.py
@@ -1,5 +1,4 @@
-from nose.tools import assert_equal, assert_raises
-
+from nose.tools import assert_equal, assert_raises, assert_true
 
 class TestKnapsack(object):
 
@@ -15,8 +14,9 @@ class TestKnapsack(object):
         total_weight = 8
         expected_value = 13
         results = knapsack.fill_knapsack(items, total_weight)
-        assert_equal(results[0].label, 'd')
-        assert_equal(results[1].label, 'b')
+        labels = [x.label for x in results]
+        assert_true('b' in labels)
+        assert_true('d' in labels)
         total_value = 0
         for item in results:
             total_value += item.value


### PR DESCRIPTION
Inputs don't need to be sorted, but we have to change how the bottom up implementation populates the results array.

We can also simplify some of the statements by:

1) removing the call to list when we create the list 'items', as there's no need for it;
2) initializing the list items with zeros; and
3) removing the if statement in the nested loop, since it's not necessary anymore because of #2.

We have to change the test too. We can't hardcode the labels to indices because they may be in a different position.