### PR TITLE
Fix missing sys import

### DIFF
--- a/stacks_queues/stack_min/test_stack_min.py
+++ b/stacks_queues/stack_min/test_stack_min.py
@@ -1,3 +1,4 @@
+import sys
 from nose.tools import assert_equal
 
 


### PR DESCRIPTION
__sys.maxsize__ is accessed on line 31 but __sys__ is not imported.

[flake8](http://flake8.pycqa.org) testing of https://github.com/donnemartin/interactive-coding-challenges on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./stacks_queues/stack_min/test_stack_min.py:30:39: F821 undefined name 'sys'
        assert_equal(stack.minimum(), sys.maxsize)
                                      ^
```