### PR TITLE
knapsack01 problem fetches incorrect item weight

### DIFF
--- a/recursion_dynamic/knapsack_01/knapsack_solution.ipynb
+++ b/recursion_dynamic/knapsack_01/knapsack_solution.ipynb
@@ -193,8 +193,8 @@
     "                j -= 1\n",
     "            else:\n",
     "                results.append(items[i])\n",
-    "                i -= 1\n",
     "                j -= items[i].weight\n",
+    "                i -= 1\n",
     "        return results"
    ]
   },


### PR DESCRIPTION
I think this is a bug because item weight won't be subtracting the current weight correctly if you subtract the row earlier.