### PR TITLE
Fix sort_stack pseudocode and test cases text

### DIFF
--- a/stacks_queues/sort_stack/sort_stack_challenge.ipynb
+++ b/stacks_queues/sort_stack/sort_stack_challenge.ipynb
@@ -50,7 +50,7 @@
    "source": [
     "## Test Cases\n",
     "\n",
-    "* Empty stack -> None\n",
+    "* Empty stack -> empty stack\n",
     "* One element stack\n",
     "* Two or more element stack (general case)\n",
     "* Already sorted stack"

--- a/stacks_queues/sort_stack/sort_stack_solution.ipynb
+++ b/stacks_queues/sort_stack/sort_stack_solution.ipynb
@@ -49,7 +49,7 @@
    "source": [
     "## Test Cases\n",
     "\n",
-    "* Empty stack -> None\n",
+    "* Empty stack -> empty stack\n",
     "* One element stack\n",
     "* Two or more element stack (general case)\n",
     "* Already sorted stack"
@@ -61,10 +61,10 @@
    "source": [
     "## Algorithm\n",
     "\n",
-    "* Our buffer will hold elements in reverse sorted order, smallest at the top\n",
-    "* Store the current top element in a temp variable\n",
+    "* Our buffer will hold elements in sorted order, largest at the top\n",
     "* While stack is not empty\n",
-    "    * While buffer is not empty or buffer top is > than temp\n",
+    "    * Pop the current top element of stack into a temp variable\n",
+    "    * While buffer is not empty and buffer top is > than temp\n",
     "        * Move buffer top to stack\n",
     "    * Move temp to top of buffer\n",
     "* Return buffer\n",


### PR DESCRIPTION
Here are some suggestions I have for the wording of sort_stack_challenge.ipynb and sort_stack_solution.ipynb, to reflect the actual code and test cases more accurately:

- Based on the code and the test cases, the output given an empty stack should be another empty stack, not None
- Buffer stores elements in sorted order, with largest element at top, not reverse sorted order with smallest element at top. Otherwise, how could we return buffer as our answer when the output should have the largest element at the top?
- While buffer is not empty **and** buffer top is > than temp (not **or**)
- Clarify that the top element is not just copied to a temp variable, but rather popped off into the temp variable. This happens within the while loop, not before.