### PR TITLE
Adding test case to catch faulty solution for permutation-challenge

### DIFF
--- a/arrays_strings/permutation/permutation_challenge.ipynb
+++ b/arrays_strings/permutation/permutation_challenge.ipynb
@@ -124,6 +124,7 @@
     "        self.assertEqual(func('act', 'cat'), True)\n",
     "        self.assertEqual(func('a ct', 'ca t'), True)\n",
     "        self.assertEqual(func('dog', 'doggo'), False)\n",
+    "        self.assertEqual(func('dogoo', 'dogcc'), False)\n",
     "        print('Success: test_permutation')\n",
     "\n",
     "\n",

--- a/arrays_strings/permutation/permutation_solution.ipynb
+++ b/arrays_strings/permutation/permutation_solution.ipynb
@@ -196,6 +196,7 @@
     "        self.assertEqual(func('act', 'cat'), True)\n",
     "        self.assertEqual(func('a ct', 'ca t'), True)\n",
     "        self.assertEqual(func('dog', 'doggo'), False)\n",
+    "        self.assertEqual(func('dogoo', 'dogcc'), False)\n",
     "        print('Success: test_permutation')\n",
     "\n",
     "\n",


### PR DESCRIPTION
There is a solution floating about where the algorithm suggests to: 

- Iterate through through both string, storing the frequency of the character occurrences in a hashmap.
- Iterate through hashmap to check if all counts are divisible by 2.

Currently, for this solution, the test cases pass. It ideally should not. 
The test case add in the PR will, detect such a solution, and fail it. 