### PR TITLE
Fix test case of pairwise swap

### DIFF
--- a/bit_manipulation/pairwise_swap/pairwise_swap_challenge.ipynb
+++ b/bit_manipulation/pairwise_swap/pairwise_swap_challenge.ipynb
@@ -2,21 +2,20 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "This notebook was prepared by [Donne Martin](https://github.com/donnemartin). Source and license info is on [GitHub](https://github.com/donnemartin/interactive-coding-challenges)."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "# Challenge Notebook"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Problem: Swap the odd and even bits of a positive integer with as few operations as possible.\n",
     "\n",
@@ -26,11 +25,11 @@
     "* [Code](#Code)\n",
     "* [Unit Test](#Unit-Test)\n",
     "* [Solution Notebook](#Solution-Notebook)"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Constraints\n",
     "\n",
@@ -44,11 +43,11 @@
     "    * No\n",
     "* Can we assume this fits memory?\n",
     "    * Yes"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Test Cases\n",
     "\n",
@@ -60,56 +59,55 @@
     "    input  = 1001 1111 0110\n",
     "    result = 0110 1111 1001\n",
     "<pre>"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Algorithm\n",
     "\n",
     "Refer to the [Solution Notebook]().  If you are stuck and need a hint, the solution notebook's algorithm discussion might be a good place to start."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Code"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "class Bits(object):\n",
     "\n",
     "    def pairwise_swap(self, num):\n",
     "        # TODO: Implement me\n",
     "        pass"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Unit Test"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "**The following unit test is expected to fail until you solve the challenge.**"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "# %load test_pairwise_swap.py\n",
     "import unittest\n",
@@ -120,7 +118,7 @@
     "    def test_pairwise_swap(self):\n",
     "        bits = Bits()\n",
     "        self.assertEqual(bits.pairwise_swap(0), 0)\n",
-    "        self.assertEqual(bits.pairwise_swap(1), 1)\n",
+    "        self.assertEqual(bits.pairwise_swap(1), 2)\n",
     "        num = int('0000100111110110', base=2)\n",
     "        expected = int('0000011011111001', base=2)\n",
     "        self.assertEqual(bits.pairwise_swap(num), expected)\n",
@@ -134,16 +132,18 @@
     "\n",
     "if __name__ == '__main__':\n",
     "    main()"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Solution Notebook\n",
     "\n",
     "Review the [Solution Notebook]() for a discussion on algorithms and code solutions."
-   ]
+   ],
+   "metadata": {}
   }
  ],
  "metadata": {


### PR DESCRIPTION
This PR is about fixing the pairswap test case that highlighted in the issue [#306 ](https://github.com/donnemartin/interactive-coding-challenges/issues/306)

bits.pairwise_swap(1) answer should be 2 (i.e. binary 10) instead of 1.